### PR TITLE
Attempt at fixing master to compile on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,8 @@ CC_FLAGS += \
 	-Ibin/$(FULL_VARIANT_REL)/cpython
 
 LD_FLAGS += 
-EMBEDDED_LIBS += $(LIBPYTHON) -lutil
+EMBEDDED_LIBS += $(LIBPYTHON)
+# No libutil in macOS (http://www.finkproject.org/doc/porting/porting.en.html 1.4)
 
 endif # WITHPYTHON
 
@@ -136,7 +137,7 @@ else
 $(TARGET): $(OBJECTS)
 endif
 	@echo Linking $@...
-	$(SHOW)$(CC) -shared -o $@ $(OBJECTS) $(LD_FLAGS) -Wl,--whole-archive $(EMBEDDED_LIBS) -Wl,--no-whole-archive
+	$(SHOW)$(CC) -shared -o $@ $(OBJECTS) $(LD_FLAGS) -Wl,-static $(EMBEDDED_LIBS) -Wl
 	$(SHOW)ln -sf $(TARGET) $(notdir $(TARGET))
 
 static: $(TARGET:.so=.a)

--- a/build/cpython/Makefile
+++ b/build/cpython/Makefile
@@ -15,6 +15,7 @@ BUILD_DIR=$(BINDIR)
 
 SRCDIR=$(ROOT)/deps/cpython
 
+# No /opt in macOS
 export CPYTHON_PREFIX=/opt/redislabs/lib/modules/python27
 PYENV_DIR=$(CPYTHON_PREFIX)/.venv
 

--- a/deps/readies/paella/setup.py
+++ b/deps/readies/paella/setup.py
@@ -80,7 +80,7 @@ class Setup(OnPlatform):
         self.run("pacman --noconfirm -S " + packs)
 
     def brew_install(self, packs, group=False):
-        self.run('brew install -y ' + packs)
+        self.run('brew install ' + packs)
 
     def install(self, packs, group=False):
         if self.os == 'linux':
@@ -98,6 +98,9 @@ class Setup(OnPlatform):
                 Assert(False), "Cannot determine installer"
         elif self.os == 'macosx':
             self.brew_install(packs, group)
+            # TODO: also brew install python2.7, otherwise the default osx's is used which doesn't have pip and installing it is impossible-ish
+            # TODO: also brew install pipenv
+            # TODO: verify that xcode command line tools are installed? (`xcode-select --install`)
         else:
             Assert(False), "Cannot determine installer"
 
@@ -116,7 +119,7 @@ class Setup(OnPlatform):
         get_pip = "set -e; cd /tmp; curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py"
         if not self.has_command("pip"):
             self.install("curl")
-            self.run(get_pip + "; python2 get-pip.py")
+            self.run(get_pip + "; python get-pip.py")
         ## fails on ubuntu 18:
         # if not has_command("pip3") and has_command("python3"):
         #     run(get_pip + "; python3 get-pip.py")


### PR DESCRIPTION
Currently stuck below /cc @rafie:

```
$ make all SHOW=1
Linking bin/macosx-x64-release/redisgears.so...
gcc -shared -o bin/macosx-x64-release/redisgears.so ./bin/macosx-x64-release/src/utils/adlist.o ./bin/macosx-x64-release/src/utils/buffer.o ./bin/macosx-x64-release/src/utils/dict.o ./bin/macosx-x64-release/src/module.o ./bin/macosx-x64-release/src/execution_plan.o ./bin/macosx-x64-release/src/mgmt.o ./bin/macosx-x64-release/src/keys_reader.o ./bin/macosx-x64-release/src/keys_writer.o ./bin/macosx-x64-release/src/example.o ./bin/macosx-x64-release/src/filters.o ./bin/macosx-x64-release/src/mappers.o ./bin/macosx-x64-release/src/extractors.o ./bin/macosx-x64-release/src/reducers.o ./bin/macosx-x64-release/src/record.o ./bin/macosx-x64-release/src/cluster.o ./bin/macosx-x64-release/src/commands.o ./bin/macosx-x64-release/src/streams_reader.o ./bin/macosx-x64-release/src/globals.o ./bin/macosx-x64-release/src/config.o ./bin/macosx-x64-release/src/lock_handler.o ./bin/macosx-x64-release/src/module_init.o ./bin/macosx-x64-release/src/redisgears_python.o  -Wl,-static bin/macosx-x64-release/cpython/libpython2.7.a bin/macosx-x64-release/libevent/.libs/libevent.a -Wl
ld: library not found for -lSystem
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [bin/macosx-x64-release/redisgears.so] Error 1
```

Signed-off-by: Itamar Haber <itamar@redislabs.com>